### PR TITLE
correct error to be InvalidArgument

### DIFF
--- a/lib/pipe/writer.lua
+++ b/lib/pipe/writer.lua
@@ -197,7 +197,7 @@ end
 function _M.make_buffer_writer(buffer, do_concat)
     do_concat = (do_concat ~= false)
     if buffer == nil then
-        return nil, 'InvalidArguments', 'buffer is nil'
+        return nil, 'InvalidArgument', 'buffer is nil'
     end
 
     return function(pobj, ident)


### PR DESCRIPTION
correct error from "InvalidArguments" to be "InvalidArgument",
removing 's' char.